### PR TITLE
Device protection

### DIFF
--- a/cloud/describe.proto
+++ b/cloud/describe.proto
@@ -40,6 +40,19 @@ enum FirmwareModuleValidityFlag {
 }
 
 /**
+ * Firmware module security
+ */
+enum FirmwareModuleSecurityMode {
+  NONE = 0;
+  PROTECTED = 1;
+}
+
+message FirmwareModuleSecurity {
+  FirmwareModuleSecurityMode mode = 1; ///< Security mode
+  bytes certificate_fingerprint = 2; ///< Certificate fingerprint (SHA-256)
+}
+
+/**
  * Firmware module dependency.
  */
 message FirmwareModuleDependency {
@@ -70,6 +83,7 @@ message FirmwareModule {
   repeated FirmwareModuleDependency dependencies = 9; ///< Module dependencies
   repeated FirmwareModuleAsset asset_dependencies = 10; ///< Asset dependencies
   uint32 size = 11; ///< Actual module size
+  FirmwareModuleSecurity security = 12; ///< Security mode
 }
 
 /**
@@ -81,4 +95,5 @@ message SystemDescribe {
   optional string iccid = 3; ///< ICCID (cellular platforms only)
   optional string modem_firmware_version = 4; ///< Modem firmware version (cellular platforms only)
   repeated FirmwareModuleAsset assets = 5; ///< List of valid assets currently present in device storage
+  bool protected = 6; ///< Protected state
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -159,7 +159,7 @@ Type: [Object][20]
 
 [16]: #properties-1
 
-[17]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L15-L20 "Source code on GitHub"
+[17]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L15-L20 "Source code on GitHub"
 
 [18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
@@ -169,26 +169,26 @@ Type: [Object][20]
 
 [21]: https://nodejs.org/api/buffer.html
 
-[22]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L45-L48 "Source code on GitHub"
+[22]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L45-L48 "Source code on GitHub"
 
-[23]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L54-L71 "Source code on GitHub"
+[23]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L54-L71 "Source code on GitHub"
 
 [24]: #protobufdefinition
 
-[25]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L93-L107 "Source code on GitHub"
+[25]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L93-L107 "Source code on GitHub"
 
 [26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[27]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L112-L120 "Source code on GitHub"
+[27]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L112-L120 "Source code on GitHub"
 
-[28]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L173-L173 "Source code on GitHub"
+[28]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L173-L173 "Source code on GitHub"
 
-[29]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L179-L179 "Source code on GitHub"
+[29]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L179-L179 "Source code on GitHub"
 
-[30]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L73-L78 "Source code on GitHub"
+[30]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L73-L78 "Source code on GitHub"
 
 [31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[33]: https://github.com/particle-iot/device-os-protobuf/blob/82ee6e508124cfd703edfa0440c8ccbf583118ad/src/index.js#L81-L87 "Source code on GitHub"
+[33]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L81-L87 "Source code on GitHub"

--- a/src/pbjs-generated/definitions.d.ts
+++ b/src/pbjs-generated/definitions.d.ts
@@ -11457,6 +11457,63 @@ export namespace particle {
             MODULE_PLATFORM_VALID_FLAG = 16
         }
 
+        /** Firmware module security */
+        enum FirmwareModuleSecurityMode {
+            NONE = 0,
+            PROTECTED = 1
+        }
+
+        /** Properties of a FirmwareModuleSecurity. */
+        interface IFirmwareModuleSecurity {
+
+            /** < Security mode */
+            mode?: (particle.cloud.FirmwareModuleSecurityMode|null);
+
+            /** < Certificate fingerprint (SHA-256) */
+            certificateFingerprint?: (Uint8Array|null);
+        }
+
+        /** Represents a FirmwareModuleSecurity. */
+        class FirmwareModuleSecurity implements IFirmwareModuleSecurity {
+
+            /**
+             * Constructs a new FirmwareModuleSecurity.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: particle.cloud.IFirmwareModuleSecurity);
+
+            /** < Security mode */
+            public mode: particle.cloud.FirmwareModuleSecurityMode;
+
+            /** < Certificate fingerprint (SHA-256) */
+            public certificateFingerprint: Uint8Array;
+
+            /**
+             * Creates a new FirmwareModuleSecurity instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns FirmwareModuleSecurity instance
+             */
+            public static create(properties?: particle.cloud.IFirmwareModuleSecurity): particle.cloud.FirmwareModuleSecurity;
+
+            /**
+             * Encodes the specified FirmwareModuleSecurity message. Does not implicitly {@link particle.cloud.FirmwareModuleSecurity.verify|verify} messages.
+             * @param message FirmwareModuleSecurity message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: particle.cloud.IFirmwareModuleSecurity, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a FirmwareModuleSecurity message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns FirmwareModuleSecurity
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): particle.cloud.FirmwareModuleSecurity;
+        }
+
         /** Properties of a FirmwareModuleDependency. */
         interface IFirmwareModuleDependency {
 
@@ -11612,6 +11669,9 @@ export namespace particle {
 
             /** < Actual module size */
             size?: (number|null);
+
+            /** < Security mode */
+            security?: (particle.cloud.IFirmwareModuleSecurity|null);
         }
 
         /** Firmware module info. */
@@ -11655,6 +11715,9 @@ export namespace particle {
 
             /** < Actual module size */
             public size: number;
+
+            /** < Security mode */
+            public security?: (particle.cloud.IFirmwareModuleSecurity|null);
 
             /** FirmwareModule _hash. */
             public _hash?: "hash";
@@ -11702,6 +11765,9 @@ export namespace particle {
 
             /** < List of valid assets currently present in device storage */
             assets?: (particle.cloud.IFirmwareModuleAsset[]|null);
+
+            /** < Protected state */
+            "protected"?: (boolean|null);
         }
 
         /** System describe. */
@@ -11727,6 +11793,9 @@ export namespace particle {
 
             /** < List of valid assets currently present in device storage */
             public assets: particle.cloud.IFirmwareModuleAsset[];
+
+            /** < Protected state */
+            public protected: boolean;
 
             /** SystemDescribe _imei. */
             public _imei?: "imei";

--- a/src/pbjs-generated/definitions.js
+++ b/src/pbjs-generated/definitions.js
@@ -23939,6 +23939,127 @@
                 return values;
             })();
     
+            /**
+             * Firmware module security
+             * @name particle.cloud.FirmwareModuleSecurityMode
+             * @enum {number}
+             * @property {number} NONE=0 NONE value
+             * @property {number} PROTECTED=1 PROTECTED value
+             */
+            cloud.FirmwareModuleSecurityMode = (function() {
+                var valuesById = {}, values = Object.create(valuesById);
+                values[valuesById[0] = "NONE"] = 0;
+                values[valuesById[1] = "PROTECTED"] = 1;
+                return values;
+            })();
+    
+            cloud.FirmwareModuleSecurity = (function() {
+    
+                /**
+                 * Properties of a FirmwareModuleSecurity.
+                 * @memberof particle.cloud
+                 * @interface IFirmwareModuleSecurity
+                 * @property {particle.cloud.FirmwareModuleSecurityMode|null} [mode] < Security mode
+                 * @property {Uint8Array|null} [certificateFingerprint] < Certificate fingerprint (SHA-256)
+                 */
+    
+                /**
+                 * Constructs a new FirmwareModuleSecurity.
+                 * @memberof particle.cloud
+                 * @classdesc Represents a FirmwareModuleSecurity.
+                 * @implements IFirmwareModuleSecurity
+                 * @constructor
+                 * @param {particle.cloud.IFirmwareModuleSecurity=} [properties] Properties to set
+                 */
+                function FirmwareModuleSecurity(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+    
+                /**
+                 * < Security mode
+                 * @member {particle.cloud.FirmwareModuleSecurityMode} mode
+                 * @memberof particle.cloud.FirmwareModuleSecurity
+                 * @instance
+                 */
+                FirmwareModuleSecurity.prototype.mode = 0;
+    
+                /**
+                 * < Certificate fingerprint (SHA-256)
+                 * @member {Uint8Array} certificateFingerprint
+                 * @memberof particle.cloud.FirmwareModuleSecurity
+                 * @instance
+                 */
+                FirmwareModuleSecurity.prototype.certificateFingerprint = $util.newBuffer([]);
+    
+                /**
+                 * Creates a new FirmwareModuleSecurity instance using the specified properties.
+                 * @function create
+                 * @memberof particle.cloud.FirmwareModuleSecurity
+                 * @static
+                 * @param {particle.cloud.IFirmwareModuleSecurity=} [properties] Properties to set
+                 * @returns {particle.cloud.FirmwareModuleSecurity} FirmwareModuleSecurity instance
+                 */
+                FirmwareModuleSecurity.create = function create(properties) {
+                    return new FirmwareModuleSecurity(properties);
+                };
+    
+                /**
+                 * Encodes the specified FirmwareModuleSecurity message. Does not implicitly {@link particle.cloud.FirmwareModuleSecurity.verify|verify} messages.
+                 * @function encode
+                 * @memberof particle.cloud.FirmwareModuleSecurity
+                 * @static
+                 * @param {particle.cloud.IFirmwareModuleSecurity} message FirmwareModuleSecurity message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                FirmwareModuleSecurity.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.mode != null && Object.hasOwnProperty.call(message, "mode"))
+                        writer.uint32(/* id 1, wireType 0 =*/8).int32(message.mode);
+                    if (message.certificateFingerprint != null && Object.hasOwnProperty.call(message, "certificateFingerprint"))
+                        writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.certificateFingerprint);
+                    return writer;
+                };
+    
+                /**
+                 * Decodes a FirmwareModuleSecurity message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof particle.cloud.FirmwareModuleSecurity
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {particle.cloud.FirmwareModuleSecurity} FirmwareModuleSecurity
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                FirmwareModuleSecurity.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.particle.cloud.FirmwareModuleSecurity();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.mode = reader.int32();
+                            break;
+                        case 2:
+                            message.certificateFingerprint = reader.bytes();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+    
+                return FirmwareModuleSecurity;
+            })();
+    
             cloud.FirmwareModuleDependency = (function() {
     
                 /**
@@ -24212,6 +24333,7 @@
                  * @property {Array.<particle.cloud.IFirmwareModuleDependency>|null} [dependencies] < Module dependencies
                  * @property {Array.<particle.cloud.IFirmwareModuleAsset>|null} [assetDependencies] < Asset dependencies
                  * @property {number|null} [size] < Actual module size
+                 * @property {particle.cloud.IFirmwareModuleSecurity|null} [security] < Security mode
                  */
     
                 /**
@@ -24319,6 +24441,14 @@
                  */
                 FirmwareModule.prototype.size = 0;
     
+                /**
+                 * < Security mode
+                 * @member {particle.cloud.IFirmwareModuleSecurity|null|undefined} security
+                 * @memberof particle.cloud.FirmwareModule
+                 * @instance
+                 */
+                FirmwareModule.prototype.security = null;
+    
                 // OneOf field names bound to virtual getters and setters
                 var $oneOfFields;
     
@@ -24381,6 +24511,8 @@
                             $root.particle.cloud.FirmwareModuleAsset.encode(message.assetDependencies[i], writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
                     if (message.size != null && Object.hasOwnProperty.call(message, "size"))
                         writer.uint32(/* id 11, wireType 0 =*/88).uint32(message.size);
+                    if (message.security != null && Object.hasOwnProperty.call(message, "security"))
+                        $root.particle.cloud.FirmwareModuleSecurity.encode(message.security, writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
                     return writer;
                 };
     
@@ -24439,6 +24571,9 @@
                         case 11:
                             message.size = reader.uint32();
                             break;
+                        case 12:
+                            message.security = $root.particle.cloud.FirmwareModuleSecurity.decode(reader, reader.uint32());
+                            break;
                         default:
                             reader.skipType(tag & 7);
                             break;
@@ -24461,6 +24596,7 @@
                  * @property {string|null} [iccid] < ICCID (cellular platforms only)
                  * @property {string|null} [modemFirmwareVersion] < Modem firmware version (cellular platforms only)
                  * @property {Array.<particle.cloud.IFirmwareModuleAsset>|null} [assets] < List of valid assets currently present in device storage
+                 * @property {boolean|null} ["protected"] < Protected state
                  */
     
                 /**
@@ -24519,6 +24655,14 @@
                  * @instance
                  */
                 SystemDescribe.prototype.assets = $util.emptyArray;
+    
+                /**
+                 * < Protected state
+                 * @member {boolean} protected
+                 * @memberof particle.cloud.SystemDescribe
+                 * @instance
+                 */
+                SystemDescribe.prototype["protected"] = false;
     
                 // OneOf field names bound to virtual getters and setters
                 var $oneOfFields;
@@ -24592,6 +24736,8 @@
                     if (message.assets != null && message.assets.length)
                         for (var i = 0; i < message.assets.length; ++i)
                             $root.particle.cloud.FirmwareModuleAsset.encode(message.assets[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                    if (message["protected"] != null && Object.hasOwnProperty.call(message, "protected"))
+                        writer.uint32(/* id 6, wireType 0 =*/48).bool(message["protected"]);
                     return writer;
                 };
     
@@ -24631,6 +24777,9 @@
                             if (!(message.assets && message.assets.length))
                                 message.assets = [];
                             message.assets.push($root.particle.cloud.FirmwareModuleAsset.decode(reader, reader.uint32()));
+                            break;
+                        case 6:
+                            message["protected"] = reader.bool();
                             break;
                         default:
                             reader.skipType(tag & 7);

--- a/src/pbjs-generated/definitions.json
+++ b/src/pbjs-generated/definitions.json
@@ -3166,6 +3166,24 @@
                 "MODULE_PLATFORM_VALID_FLAG": 16
               }
             },
+            "FirmwareModuleSecurityMode": {
+              "values": {
+                "NONE": 0,
+                "PROTECTED": 1
+              }
+            },
+            "FirmwareModuleSecurity": {
+              "fields": {
+                "mode": {
+                  "type": "FirmwareModuleSecurityMode",
+                  "id": 1
+                },
+                "certificateFingerprint": {
+                  "type": "bytes",
+                  "id": 2
+                }
+              }
+            },
             "FirmwareModuleDependency": {
               "fields": {
                 "type": {
@@ -3259,6 +3277,10 @@
                 "size": {
                   "type": "uint32",
                   "id": 11
+                },
+                "security": {
+                  "type": "FirmwareModuleSecurity",
+                  "id": 12
                 }
               }
             },
@@ -3311,6 +3333,10 @@
                   "rule": "repeated",
                   "type": "FirmwareModuleAsset",
                   "id": 5
+                },
+                "protected": {
+                  "type": "bool",
+                  "id": 6
                 }
               }
             }


### PR DESCRIPTION
Adds fields for reporting device protection in describe and in modules.

Note: SystemDescribe.protected is not marked optional because I don't think the cloud needs field presence (no need to distinguish between false and "field not sent").

There were more changes than those related to protection when I ran `npm run build`. If you run `npm run build` and your changeset is smaller, you can amend my commit and force push.
- Thanks for regenerating the files, Sergey!