### PR TITLE
Can't use protected as a field name in C++

### DIFF
--- a/cloud/describe.proto
+++ b/cloud/describe.proto
@@ -95,5 +95,5 @@ message SystemDescribe {
   optional string iccid = 3; ///< ICCID (cellular platforms only)
   optional string modem_firmware_version = 4; ///< Modem firmware version (cellular platforms only)
   repeated FirmwareModuleAsset assets = 5; ///< List of valid assets currently present in device storage
-  bool protected = 6; ///< Protected state
+  bool protected_state = 6; ///< Protected state
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -159,7 +159,7 @@ Type: [Object][20]
 
 [16]: #properties-1
 
-[17]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L15-L20 "Source code on GitHub"
+[17]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L15-L20 "Source code on GitHub"
 
 [18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
@@ -169,26 +169,26 @@ Type: [Object][20]
 
 [21]: https://nodejs.org/api/buffer.html
 
-[22]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L45-L48 "Source code on GitHub"
+[22]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L45-L48 "Source code on GitHub"
 
-[23]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L54-L71 "Source code on GitHub"
+[23]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L54-L71 "Source code on GitHub"
 
 [24]: #protobufdefinition
 
-[25]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L93-L107 "Source code on GitHub"
+[25]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L93-L107 "Source code on GitHub"
 
 [26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[27]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L112-L120 "Source code on GitHub"
+[27]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L112-L120 "Source code on GitHub"
 
-[28]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L173-L173 "Source code on GitHub"
+[28]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L173-L173 "Source code on GitHub"
 
-[29]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L179-L179 "Source code on GitHub"
+[29]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L179-L179 "Source code on GitHub"
 
-[30]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L73-L78 "Source code on GitHub"
+[30]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L73-L78 "Source code on GitHub"
 
 [31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[33]: https://github.com/particle-iot/device-os-protobuf/blob/3a279386d834c74bc656cd2d883ca84aca8d97ac/src/index.js#L81-L87 "Source code on GitHub"
+[33]: https://github.com/particle-iot/device-os-protobuf/blob/63bb38e19c806da849451f0f553bbce0226c7140/src/index.js#L81-L87 "Source code on GitHub"

--- a/src/pbjs-generated/definitions.d.ts
+++ b/src/pbjs-generated/definitions.d.ts
@@ -11767,7 +11767,7 @@ export namespace particle {
             assets?: (particle.cloud.IFirmwareModuleAsset[]|null);
 
             /** < Protected state */
-            "protected"?: (boolean|null);
+            protectedState?: (boolean|null);
         }
 
         /** System describe. */
@@ -11795,7 +11795,7 @@ export namespace particle {
             public assets: particle.cloud.IFirmwareModuleAsset[];
 
             /** < Protected state */
-            public protected: boolean;
+            public protectedState: boolean;
 
             /** SystemDescribe _imei. */
             public _imei?: "imei";

--- a/src/pbjs-generated/definitions.js
+++ b/src/pbjs-generated/definitions.js
@@ -24596,7 +24596,7 @@
                  * @property {string|null} [iccid] < ICCID (cellular platforms only)
                  * @property {string|null} [modemFirmwareVersion] < Modem firmware version (cellular platforms only)
                  * @property {Array.<particle.cloud.IFirmwareModuleAsset>|null} [assets] < List of valid assets currently present in device storage
-                 * @property {boolean|null} ["protected"] < Protected state
+                 * @property {boolean|null} [protectedState] < Protected state
                  */
     
                 /**
@@ -24658,11 +24658,11 @@
     
                 /**
                  * < Protected state
-                 * @member {boolean} protected
+                 * @member {boolean} protectedState
                  * @memberof particle.cloud.SystemDescribe
                  * @instance
                  */
-                SystemDescribe.prototype["protected"] = false;
+                SystemDescribe.prototype.protectedState = false;
     
                 // OneOf field names bound to virtual getters and setters
                 var $oneOfFields;
@@ -24736,8 +24736,8 @@
                     if (message.assets != null && message.assets.length)
                         for (var i = 0; i < message.assets.length; ++i)
                             $root.particle.cloud.FirmwareModuleAsset.encode(message.assets[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                    if (message["protected"] != null && Object.hasOwnProperty.call(message, "protected"))
-                        writer.uint32(/* id 6, wireType 0 =*/48).bool(message["protected"]);
+                    if (message.protectedState != null && Object.hasOwnProperty.call(message, "protectedState"))
+                        writer.uint32(/* id 6, wireType 0 =*/48).bool(message.protectedState);
                     return writer;
                 };
     
@@ -24779,7 +24779,7 @@
                             message.assets.push($root.particle.cloud.FirmwareModuleAsset.decode(reader, reader.uint32()));
                             break;
                         case 6:
-                            message["protected"] = reader.bool();
+                            message.protectedState = reader.bool();
                             break;
                         default:
                             reader.skipType(tag & 7);

--- a/src/pbjs-generated/definitions.json
+++ b/src/pbjs-generated/definitions.json
@@ -3334,7 +3334,7 @@
                   "type": "FirmwareModuleAsset",
                   "id": 5
                 },
-                "protected": {
+                "protectedState": {
                   "type": "bool",
                   "id": 6
                 }


### PR DESCRIPTION
Rename `protected` to `protected_state` to avoid errors when using this field in the C++ code base of Device OS