### PR TITLE
Validate order of message fields

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -418,7 +418,9 @@ describe('deviceOSProtobuf', () => {
 				'SetInterfaceStoredConfigurationRequest',
 				'SetInterfaceStoredConfigurationReply',
 				'DeleteInterfaceStoredConfigurationRequest',
-				'DeleteInterfaceStoredConfigurationReply'
+				'DeleteInterfaceStoredConfigurationReply',
+				'GetProtectedStateRequest',
+				'GetProtectedStateReply'
 			]);
 
 			const missingDefs = [];


### PR DESCRIPTION
Following the discussion in [device-os/#2715](https://github.com/particle-iot/device-os/pull/2715#discussion_r1474648016), this PR adds a test that validates the order in which message fields are encoded.